### PR TITLE
Fixed menu item horizontal position

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -71,11 +71,10 @@ class Extension {
   enable() {
     this.proxy = new Manager(Gio.DBus.system, 'org.freedesktop.login1', '/org/freedesktop/login1');
 
-    //  I don't know why but if I added the menu item directly the text appeared too far to the left in Gnome 43. 
-    //  I had to use this little trick of adding whitespaces to make it appear in the right position.
-    const trickySpaces = this.isPreQuickSettings ? '' : '      ';
-    const itemLabel = `${trickySpaces}${_('Restart to UEFI')}...`;
-    this.rebootToUefiItem = new PopupMenu.PopupImageMenuItem(itemLabel, '');
+    const itemLabel = 'Restart to UEFI...';
+    this.rebootToUefiItem = this.isPreQuickSettings
+      ? new PopupMenu.PopupImageMenuItem(itemLabel, '')
+      : new PopupMenu.PopupMenuItem(itemLabel);
 
     this.rebootToUefiItem.connect('activate', () => {
       this.counter = 60;


### PR DESCRIPTION
Changed the menu item creation from `PopupMenu.PopupImageMenuItem(itemLabel, '')` to `PopupMenu.PopupMenuItem(itemLabel)`.

Before:
![Screenshot from 2023-01-21 22-02-52](https://user-images.githubusercontent.com/32330783/213887094-0922e3d5-0c42-4e1f-90b9-b7d22fab16c8.png)

After:
![Screenshot from 2023-01-21 22-03-45](https://user-images.githubusercontent.com/32330783/213887099-88cbcf6f-21d8-4094-af6d-e62f39a4800c.png)
