### PR TITLE
Add support for GNOME 49

### DIFF
--- a/src/metadata.json
+++ b/src/metadata.json
@@ -4,6 +4,6 @@
   "license": "GPLv3",
   "uuid": "reboottouefi@ubaygd.com",
   "url": "https://github.com/UbayGD/reboottouefi",
-  "shell-version": ["45", "46", "47", "48"],
+  "shell-version": ["45", "46", "47", "48", "49"],
   "gettext-domain": "reboottouefi@ubaygd.com"
 }


### PR DESCRIPTION
Preparing for GNOME 49 release next week. Tested on GNOME 49.alpha, 49.beta and 49.rc.

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/e9902c4a-9d61-48b3-8325-b21904032cfe" />