### PR TITLE
feat: add support for GNOME 50

### DIFF
--- a/src/metadata.json
+++ b/src/metadata.json
@@ -4,6 +4,6 @@
   "license": "GPLv3",
   "uuid": "reboottouefi@ubaygd.com",
   "url": "https://github.com/UbayGD/reboottouefi",
-  "shell-version": ["45", "46", "47", "48", "49"],
+  "shell-version": ["45", "46", "47", "48", "49", "50"],
   "gettext-domain": "reboottouefi@ubaygd.com"
 }


### PR DESCRIPTION
Preparing for GNOME 50.0 release on March 18.

Tested on GNOME 50.beta (UI-only) and 50.rc (UI and functionality).